### PR TITLE
Limit W3 mirroring to a depth of 2.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['content_mirror']['content'] = {
 
   'w3' => {
     method: 'wget',
+    args: '-l 2',
     remote: 'http://www.w3.org/TR/',
   },
 }


### PR DESCRIPTION
This allows for two different circumstances:
1. Top of a spec tree is the TOC, not a one-page spec
2. PDF and PS (and possibly other) renders
